### PR TITLE
BUGFIX: Regexp / getRestURL and postRestURL / race condition in SQL query

### DIFF
--- a/project/config/cmbackup.conf
+++ b/project/config/cmbackup.conf
@@ -107,3 +107,8 @@ SSL_ENABLE=true
 #              DEFAULT: /opt/zextras/bin/zmmailbox
 
 ZMMAILBOX=/opt/zextras/bin/zmmailbox
+
+# ZMMAILBOX_URL - URL for zmmailbox getRestURL and postRestURL requests.
+#                 DEFAULT: https://localhost:7071
+
+ZMMAILBOX_URL=https://localhost:7071

--- a/project/lib/bash/BackupAction.sh
+++ b/project/lib/bash/BackupAction.sh
@@ -97,7 +97,7 @@ function backup_main()
   if [[ -z $4 ]] || [[ "$3" == "-d" ]] || [[ "$3" == "--domain" ]]; then
     build_listBKP "$1" "$2" "$3" "$4"
   elif  [[ "$3" == "-a" ]] || [[ "$3" == "--account" ]]; then
-    for i in $("$4//,/\n/g"); do
+    for i in ${4//,/ }; do
       echo "$i" >> "$TEMPACCOUNT"
     done
   else

--- a/project/lib/bash/ListAction.sh
+++ b/project/lib/bash/ListAction.sh
@@ -22,7 +22,7 @@
 function build_listBKP()
 {
   if [ "$3" == "-d" ]; then
-    for i in ${4//s/\n/g}; do
+    for i in ${4//,/ }; do
       DC=",dc="
       DOMAIN="dc="${i//./$DC}
       ERR=$( (ldapsearch -Z -x -H "$LDAPSERVER" -D "$LDAPADMIN" -w "$LDAPPASS" -b "$DOMAIN" -LLL "$1" "$2" >> "$TEMPACCOUNT") 2>&1)
@@ -61,7 +61,7 @@ function build_listBKP()
 function build_listRST()
 {
   if [[ $2 == *"@"* ]]; then
-    for i in ${2//s/\n/g}; do
+    for i in ${2//,/ }; do
       echo "$i" >> "$TEMPACCOUNT"
     done
   else

--- a/project/lib/bash/MiscAction.sh
+++ b/project/lib/bash/MiscAction.sh
@@ -177,6 +177,11 @@ function validate_config(){
     logger -i -p local7.warn "Cmbackup: ZMMAILBOX not defined informed - setting as $ZMMAILBOX instead"
   fi
 
+  if [ -z "$ZMMAILBOX_URL" ]; then
+    ZMMAILBOX_URL="https://localhost:7071"
+    logger -i -p local7.warn "Cmbackup: ZMMAILBOX_URL not defined - setting as $ZMMAILBOX_URL instead"
+  fi
+
   if [ -z "$MAX_PARALLEL_PROCESS" ]; then
     MAX_PARALLEL_PROCESS="1"
     logger -i -p local7.warn "Cmbackup: MAX_PARALLEL_PROCESS not informed - disabling."
@@ -282,4 +287,5 @@ function export_vars(){
   export SESSION_TYPE
   export MAILPORT
   export ZMMAILBOX
+  export ZMMAILBOX_URL
 }

--- a/project/lib/bash/ParallelAction.sh
+++ b/project/lib/bash/ParallelAction.sh
@@ -126,9 +126,8 @@ function ldap_filter()
     if [[ "$SESSION_TYPE" == "TXT" ]]; then
       EXIST=$(grep "$1:$(date +%m/%d/%y)" "$WORKDIR"/sessions.txt 2> /dev/null | tail -1)
     else
-      TODAY=$(date +%Y-%m-%dT%H:%M:%S.%N)
-      YESTERDAY=$(date +%Y-%m-%dT%H:%M:%S.%N -d "yesterday")
-      EXIST=$(sqlite3 "$WORKDIR"/sessions.sqlite3 "select email from backup_account where conclusion_date < '$TODAY' and conclusion_date > '$YESTERDAY' and email='$1'")
+      START_OF_TODAY=$(date +%Y-%m-%dT00:00:00.000000000)
+      EXIST=$(sqlite3 "$WORKDIR"/sessions.sqlite3 "select email from backup_account where conclusion_date > '$START_OF_TODAY' and email='$1'")
     fi
   fi
   grep -Fxq "$1" /etc/cmbackup/blockedlist.conf

--- a/project/lib/bash/ParallelAction.sh
+++ b/project/lib/bash/ParallelAction.sh
@@ -50,7 +50,7 @@ function mailbox_backup()
     fi
     AFTER='&'"start=$(date -d "$DATE" +%s)000"
   fi
-  $ZMMAILBOX -t 0 -z -m "$1" getRestURL --output "$TEMPDIR"/"$1".tgz "/?fmt=tgz&resolve=skip$AFTER" > "$TEMP_CLI_OUTPUT" 2>&1
+  $ZMMAILBOX -t 0 -z -m "$1" getRestURL -u "$ZMMAILBOX_URL" --output "$TEMPDIR"/"$1".tgz "/?fmt=tgz&resolve=skip$AFTER" > "$TEMP_CLI_OUTPUT" 2>&1
   BASHERRCODE=$?
   if [[ $BASHERRCODE -eq 0 ]]; then
     if [[ -s $TEMPDIR/$1.tgz ]]; then
@@ -78,6 +78,7 @@ function mailbox_backup()
 ###############################################################################
 function ldap_restore()
 {
+  printf "\n - Restoring LDAP from %s" "$WORKDIR/$1/$2.ldiff"
   ERR=$( (ldapadd -x -H "$LDAPSERVER" -D "$LDAPADMIN" \
            -c -w "$LDAPPASS" -f "$WORKDIR"/"$1"/"$2".ldiff) 2>&1)
   BASHERRCODE=$?
@@ -95,9 +96,10 @@ function ldap_restore()
 ###############################################################################
 function mailbox_restore()
 {
+  printf "\n - Restoring Mailbox from %s" "$WORKDIR/$1/$2.tgz"
   TEMP_CLI_OUTPUT=$(mktemp)
   zmlocalconfig -e socket_so_timeout=99999999
-  $ZMMAILBOX -t 0 -z -m "$2" postRestURL '//?fmt=tgz&resolve=skip' "$WORKDIR"/"$1"/"$2".tgz > "$TEMP_CLI_OUTPUT" 2>&1
+  $ZMMAILBOX -t 0 -z -m "$2" postRestURL -u "$ZMMAILBOX_URL" '//?fmt=tgz&resolve=skip' "$WORKDIR"/"$1"/"$2".tgz > "$TEMP_CLI_OUTPUT" 2>&1
   BASHERRCODE=$?
   zmlocalconfig -u socket_so_timeout
   if ! [[ $BASHERRCODE -eq 0 ]]; then


### PR DESCRIPTION
I had to fix the following issues, so that we could use cmbackup:
- Added ZMMAILBOX_URL option and uis it wiith getRestURL/postRestURL.
- Fixed Regexp to get account list.
- Fixed sql statement to check for existing backup to only look for
    backups after midnight of today. Before it was prone to a race condition
    when the previous backup had finished a little bit later than 24 hours
    ago. Not the behavoir should be the same as with SESSION_TYPE "TXT".

We would like to share those changes with this PR.